### PR TITLE
fix: do not re-calculate expires_at if job alrady have the attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master (unreleased)
 
+- Do not recalculate `expires_at` if already exists
 - Drop support for Ruby < 3.2 and Sidekiq < 8.0
 
 ## 0.1.1 (2024-01-14)


### PR DESCRIPTION
When I used this gem in combination with sidekiq-throttled, job requeued triggered the expiration recalculation and override it to the job. I added a condition to skip the expiration calculation if the job already has the attribute calculated.