### PR TITLE
Setting min version for Sidekiq to 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master (unreleased)
 
+## 0.2.1 (2025-09-18)
+
+- Setting min sidekiq version to 6
+
 ## 0.2.0 (2025-09-15)
 
 - Do not recalculate `expires_at` if already exists

--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ gem "rubocop-minitest"
 if defined?(@sidekiq_requirement)
   gem "sidekiq", @sidekiq_requirement
 else
-  gem "sidekiq" # latest
+  gem "sidekiq", "> 6" # min sidekiq version
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rubocop (< 2)
   rubocop-minitest
-  sidekiq
+  sidekiq (> 6)
   sidekiq-expiring-jobs!
 
 BUNDLED WITH

--- a/lib/sidekiq_expiring_jobs/version.rb
+++ b/lib/sidekiq_expiring_jobs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqExpiringJobs
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
After the update, the Sidekiq requirement switched to the latest, we can use the min required version to 6 and allow all compatible versions to be used.